### PR TITLE
Fix for issue #15

### DIFF
--- a/src/it/it-pass-with-dependency-with-and-without-classifier/invoker.properties
+++ b/src/it/it-pass-with-dependency-with-and-without-classifier/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:check
+invoker.systemPropertiesFile=test.properties

--- a/src/it/it-pass-with-dependency-with-and-without-classifier/pom.xml
+++ b/src/it/it-pass-with-dependency-with-and-without-classifier/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>example</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.lewisd</groupId>
+                <artifactId>lint-maven-plugin</artifactId>
+                <version>0.0.8</version>
+            </dependency>
+            <dependency>
+                <groupId>com.lewisd</groupId>
+                <artifactId>lint-maven-plugin</artifactId>
+                <version>0.0.8</version>
+                <classifier>javadoc</classifier>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.lewisd</groupId>
+            <artifactId>lint-maven-plugin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.lewisd</groupId>
+            <artifactId>lint-maven-plugin</artifactId>
+            <classifier>javadoc</classifier>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/it/it-pass-with-dependency-with-and-without-classifier/test.properties
+++ b/src/it/it-pass-with-dependency-with-and-without-classifier/test.properties
@@ -1,0 +1,1 @@
+maven-lint.rules=RedundantDepVersion

--- a/src/it/it-pass-with-dependency-with-and-without-classifier/verify.bsh
+++ b/src/it/it-pass-with-dependency-with-and-without-classifier/verify.bsh
@@ -1,0 +1,22 @@
+source("src/it/shared/it-utils.bsh");
+
+try
+{
+    String buf = readBuildLog();
+
+    checkForWarnings(buf);
+
+    validateNoLintErrors(buf);
+
+}
+catch( ValidationException t )
+{
+    return false;
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/com/lewisd/maven/lint/rules/AbstractReduntantVersionRule.java
+++ b/src/main/java/com/lewisd/maven/lint/rules/AbstractReduntantVersionRule.java
@@ -107,11 +107,15 @@ public abstract class AbstractReduntantVersionRule extends AbstractRule {
         String type = modelUtil.tryGetType(object);
         if (type != null) {
             path.append(" and type='").append(type).append("'");
+        } else {
+            path.append(" and not(type)");
         }
 
         String classifier = modelUtil.tryGetClassifier(object);
         if (classifier != null) {
             path.append(" and classifier='").append(classifier).append("'");
+        } else {
+            path.append(" and not(classifier)");
         }
         path.append("]");
 


### PR DESCRIPTION
You were right that resolution of #4 made resolution of #15 very easy.

One question: what about testing? We can either:
1. Decide that a code review and manual testing using the POM in #15 is good enough.
2. Create an IT with the example POM and prevent the original issue from being merely logged, but have it bubble up as a fatal exception instead. (E.g. by changing the `IllegalStateException` at `AbstractReduntantVersionRule:135` to an `AssertionError`.)
3. Create an IT with the example POM and verify that no warning is logged anymore. This is probably more trouble than it's worth. (Never done this with log4j directly. If you were to use SLF4J, I'd use [slf4j-test](http://projects.lidalia.org.uk/slf4j-test/).)

Let me know what you think :)